### PR TITLE
fix null geo filter problem

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -175,7 +175,7 @@ func StartService(cfg common.AresServerConfig, logger bark.Logger, queryLogger b
 
 	batchStatsReporter := memstore.NewBatchStatsReporter(5*60, memStore, metaStore)
 	go batchStatsReporter.Run()
-  
+
 	utils.GetLogger().Infof("Starting HTTP server on port %d with max connection %d", *port, cfg.HTTP.MaxConnections)
 	utils.LimitServe(*port, handlers.CORS(allowOrigins, allowHeaders, allowMethods)(router), cfg.HTTP)
 	batchStatsReporter.Stop()

--- a/metastore/validator_test.go
+++ b/metastore/validator_test.go
@@ -119,8 +119,8 @@ var _ = ginkgo.Describe("Validator", func() {
 					Type: "Int32",
 				},
 				{
-					Name: "col2",
-					Type: "SmallEnum",
+					Name:         "col2",
+					Type:         "SmallEnum",
 					DefaultValue: &dv1,
 				},
 			},
@@ -137,8 +137,8 @@ var _ = ginkgo.Describe("Validator", func() {
 					Type: "Int32",
 				},
 				{
-					Name: "col2",
-					Type: "SmallEnum",
+					Name:         "col2",
+					Type:         "SmallEnum",
 					DefaultValue: &dv2,
 				},
 				{

--- a/query/algorithm_unittest.cu
+++ b/query/algorithm_unittest.cu
@@ -1649,9 +1649,9 @@ TEST(GeoBatchIntersectionJoinTest, DimensionWriting) {
   uint32_t indexVectorH[5] = {0, 1, 2, 3, 4};
   uint32_t *indexVector = allocate(indexVectorH, 5);
 
-  // 5 points ,(1.5,1.5),(0,0), (1.5, 3.5),(1.5,4.5),null
-  //             in2     in1,2      in3        out
-  GeoPointT pointsH[5] = {{1.5, 1.5}, {0, 0}, {1.5, 3.5}, {1.5, 4.5}, {0, 0}};
+  // 5 points  (1.5,1.5) (0,0) (1.5,4.5) (1.5, 3.5)   null
+  //             in2     in1,2  out            in3        out
+  GeoPointT pointsH[5] = {{1.5, 1.5}, {0, 0}, {1.5, 4.5}, {1.5, 3.5}, {0, 0}};
   uint8_t nullsH[1] = {0x0F};
 
   uint32_t outputPredicateH[5] = {0};
@@ -1679,16 +1679,16 @@ TEST(GeoBatchIntersectionJoinTest, DimensionWriting) {
 
   resHandle = WriteGeoShapeDim(1, outputDimension, 5, outputPredicate, 0, 0);
 
-  uint32_t expectedOutputPredicate[5] = {2, 3, 4, 0, 0};
+  uint32_t expectedOutputPredicate[5] = {2, 3, 0, 4, 0};
   GeoPredicateIterator geoIter(expectedOutputPredicate, 1);
   EXPECT_TRUE(
       equal(outputPredicate, outputPredicate + 5, expectedOutputPredicate));
   uint8_t expectedDimValues[5] = {1, 0, 2, 0, 0};
   uint8_t expectedDimNulls[5] = {1, 1, 1, 0, 0};
-  EXPECT_TRUE(equal(outputDimension.DimValues, outputDimension.DimValues + 5,
-                    expectedDimValues));
-  EXPECT_TRUE(equal(outputDimension.DimNulls, outputDimension.DimNulls + 5,
-                    expectedDimNulls));
+  EXPECT_TRUE(equal(outputDimension.DimValues,
+      outputDimension.DimValues + 5, expectedDimValues));
+  EXPECT_TRUE(equal_print(outputDimension.DimNulls,
+      outputDimension.DimNulls + 5, expectedDimNulls));
 
   release(outputPredicate);
   release(indexVector);

--- a/query/aql_processor.go
+++ b/query/aql_processor.go
@@ -931,6 +931,7 @@ func (qc *AQLQueryContext) processBatch(
 			qc.OOPK.currentBatch.geoPredicateVectorD = deviceAllocate(qc.OOPK.currentBatch.size*4*numWords, qc.Device)
 		}
 
+		sizeBeforeGeoFilter := qc.OOPK.currentBatch.size
 		qc.doProfile(func() {
 			if qc.OOPK.geoIntersection != nil {
 				pointColumnIndex := qc.TableScanners[qc.OOPK.geoIntersection.pointTableID].
@@ -956,9 +957,12 @@ func (qc *AQLQueryContext) processBatch(
 				dimVectorIndex := qc.OOPK.DimensionVectorIndex[dimIndex]
 				dimValueOffset, dimNullOffset := queryCom.GetDimensionStartOffsets(qc.OOPK.NumDimsPerDimWidth, dimVectorIndex, qc.OOPK.currentBatch.resultCapacity)
 				if qc.OOPK.geoIntersection != nil && qc.OOPK.geoIntersection.dimIndex == dimIndex {
+					for i :=0 ; i < qc.OOPK.currentBatch.size; i++{
+						fmt.Println(*(*uint32)(memutils.MemAccess(qc.OOPK.currentBatch.geoPredicateVectorD.getPointer(), 4 * i)))
+					}
 					qc.OOPK.currentBatch.writeGeoShapeDim(
 						qc.OOPK.geoIntersection, qc.OOPK.currentBatch.geoPredicateVectorD,
-						dimValueOffset, dimNullOffset, stream, qc.Device)
+						dimValueOffset, dimNullOffset, sizeBeforeGeoFilter, stream, qc.Device)
 				} else {
 					dimensionExprRootAction := qc.OOPK.currentBatch.makeWriteToDimensionVectorAction(dimValueOffset, dimNullOffset)
 					qc.OOPK.currentBatch.processExpression(dimension, nil,

--- a/query/aql_processor.go
+++ b/query/aql_processor.go
@@ -957,9 +957,6 @@ func (qc *AQLQueryContext) processBatch(
 				dimVectorIndex := qc.OOPK.DimensionVectorIndex[dimIndex]
 				dimValueOffset, dimNullOffset := queryCom.GetDimensionStartOffsets(qc.OOPK.NumDimsPerDimWidth, dimVectorIndex, qc.OOPK.currentBatch.resultCapacity)
 				if qc.OOPK.geoIntersection != nil && qc.OOPK.geoIntersection.dimIndex == dimIndex {
-					for i :=0 ; i < qc.OOPK.currentBatch.size; i++{
-						fmt.Println(*(*uint32)(memutils.MemAccess(qc.OOPK.currentBatch.geoPredicateVectorD.getPointer(), 4 * i)))
-					}
 					qc.OOPK.currentBatch.writeGeoShapeDim(
 						qc.OOPK.geoIntersection, qc.OOPK.currentBatch.geoPredicateVectorD,
 						dimValueOffset, dimNullOffset, sizeBeforeGeoFilter, stream, qc.Device)

--- a/query/time_series_aggregate.go
+++ b/query/time_series_aggregate.go
@@ -580,7 +580,7 @@ func (bc *oopkBatchContext) makeGeoPointInputVector(pointTableID int, pointColum
 }
 
 func (bc *oopkBatchContext) writeGeoShapeDim(geo *geoIntersection,
-	outputPredicate devicePointer, dimValueOffset, dimNullOffset int, stream unsafe.Pointer, device int) {
+	outputPredicate devicePointer, dimValueOffset, dimNullOffset int, sizeBeforeGeoFilter int, stream unsafe.Pointer, device int) {
 	if bc.size <= 0 || geo.shapeLatLongs.isNull() {
 		return
 	}
@@ -598,7 +598,7 @@ func (bc *oopkBatchContext) writeGeoShapeDim(geo *geoIntersection,
 
 	totalWords := (geo.numShapes + 31) / 32
 	doCGoCall(func() C.CGoCallResHandle {
-		return C.WriteGeoShapeDim((C.int)(totalWords), dimensionOutputVector, (C.int)(bc.size),
+		return C.WriteGeoShapeDim((C.int)(totalWords), dimensionOutputVector, (C.int)(sizeBeforeGeoFilter),
 			(*C.uint32_t)(outputPredicate.getPointer()), stream, (C.int)(device))
 	})
 }

--- a/query/time_series_aggregate.h
+++ b/query/time_series_aggregate.h
@@ -550,13 +550,15 @@ CGoCallResHandle GeoBatchIntersects(
 
 // WriteGeoShapeDim is the interface to write the shape index to the dimension
 // output. This method should be called after GeoBatchIntersects removes all
-// non-intersecting rows.
+// non-intersecting rows. Note we need pass in the index vector length before
+// geo since outputPredicate has not done compaction yet.
 // Note:
 //   1. we assume that the geo join will be many-to-one join
 //   2. we only support IN operation for geo intersects join
 CGoCallResHandle WriteGeoShapeDim(
-    int shapeTotalWords, DimensionOutputVector dimOut, int indexVectorLength,
-    uint32_t *outputPredicate, void *cudaStream, int device);
+    int shapeTotalWords, DimensionOutputVector dimOut,
+    int indexVectorLengthBeforeGeo, uint32_t *outputPredicate,
+    void *cudaStream, int device);
 
 // BoostrapDevice will bootstrap the all gpu devices with approriate actions.
 // For now it will just initialize the constant memory.


### PR DESCRIPTION
When copying the geo predicate to dimension, we need to pass in the index vector length before geo filter since the geo predicate has not done compaction yet. Also we need to change to copy if to do actual compaction
