### PR TITLE
set changed row only if non null

### DIFF
--- a/memstore/backfill.go
+++ b/memstore/backfill.go
@@ -572,7 +572,10 @@ func (ctx *backfillContext) getChangedPatchRow(patchRecordID RecordID, upsertBat
 			return nil, utils.StackError(err, "Failed to get value at row %d, col %d",
 				patchRecordID.Index, col)
 		}
-		changedRow[columnID] = &value
+
+		if value.Valid {
+			changedRow[columnID] = &value
+		}
 	}
 	return changedRow, nil
 }


### PR DESCRIPTION
since we are using k2 topics. When backfill, there will be lots of columns with null value. We need to ignore those values 