### PR TITLE
Install glide and swagger in setup phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ vendor/glide.updated: glide.lock glide.yaml
 
 deps: vendor/glide.updated $(ALL_GO_SRC)
 
+setup:
+	curl https://glide.sh/get | sh
+	go get -u github.com/go-swagger/go-swagger/cmd/swagger
+
 pwd := $(shell pwd)
 
 swagger-gen:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Build
 -----
 The following dependencies need to be installed before building the binary.
 
+### setup
+Run `make setup` to install dependencies for building the binary.
+
 ### glide
 We use [glide](https://glide.sh) to manage Go dependencies. Please make sure `glide` is in your PATH before you attempt to build.
 


### PR DESCRIPTION
- Use setup in Makefile for download dependencies required for building the binary.