### PR TITLE
fix test

### DIFF
--- a/query/device_allocator_test.go
+++ b/query/device_allocator_test.go
@@ -22,7 +22,7 @@ import (
 var _ = ginkgo.Describe("Device Allocator", func() {
 
 	ginkgo.It("deviceAllocate and deviceFree should work", func() {
-		deviceAllocator := newDeviceAllocator()
+		deviceAllocator := getDeviceAllocator()
 		dp := deviceAllocator.deviceAllocate(12, 0)
 		Ω(dp.bytes).Should(BeEquivalentTo(12))
 		Ω(dp.device).Should(BeEquivalentTo(0))
@@ -55,9 +55,10 @@ var _ = ginkgo.Describe("Device Allocator", func() {
 	})
 
 	ginkgo.It("reportAllocatedMemory should work", func() {
-		deviceAllocate(12, 0)
+		dp := deviceAllocate(12, 0)
 		da := getDeviceAllocator()
 		Ω(da.getAllocatedMemory(0)).Should(BeNumerically(">", 0))
 		Ω(func() { reportAllocatedMemory(0, da) }).ShouldNot(Panic())
+		da.deviceFree(dp)
 	})
 })


### PR DESCRIPTION
failing to release device memory in `reportAllocatedMemory should work` caused this mysterious behaviour that aql_processor test randomly fail. because its success now depend on whether it's ran before or after the `Device Allocator` suit. 