### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,12 @@ install:
   - .travis/install_cuda.sh
   - ./build/cmake/bin/cmake .
   - .travis/install_golang_tools.sh
+before_script:
+  - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 script:
   - make lint
   - make travis
+  - fossa
 after_success:
   # generate coverage output file
   - gover . coverage.txt


### PR DESCRIPTION
I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.