### PR TITLE
peer source implementation

### DIFF
--- a/datanode/client/types.go
+++ b/datanode/client/types.go
@@ -20,8 +20,10 @@ import (
 // WithConnectionFn defines function with PeerDataNodeClient
 type WithConnectionFn func(rpc.PeerDataNodeClient)
 
-// PeerSource represent a peer source
+// PeerSource represent a peer source which manages peer connections
 type PeerSource interface {
 	// BorrowConnection will borrow a connection and execute a user function.
 	BorrowConnection(hostID string, fn WithConnectionFn) error
+	// Close close peer source and all managed peers
+	Close()
 }

--- a/datanode/client/types.go
+++ b/datanode/client/types.go
@@ -24,6 +24,4 @@ type WithConnectionFn func(rpc.PeerDataNodeClient)
 type PeerSource interface {
 	// BorrowConnection will borrow a connection and execute a user function.
 	BorrowConnection(hostID string, fn WithConnectionFn) error
-	// Close close peer source and all managed peers
-	Close()
 }

--- a/datanode/peer_source.go
+++ b/datanode/peer_source.go
@@ -1,0 +1,164 @@
+package datanode
+
+import (
+	"github.com/pkg/errors"
+	"github.com/uber/aresdb/cluster/topology"
+	"github.com/uber/aresdb/datanode/client"
+	"github.com/uber/aresdb/datanode/generated/proto/rpc"
+	"github.com/uber/aresdb/utils"
+	"google.golang.org/grpc"
+	"sync"
+)
+
+var (
+	errPeerClosed   = errors.New("peer closed")
+	errPeerNotExist = errors.New("peer does not exist")
+)
+
+type peer struct {
+	sync.RWMutex
+	sync.WaitGroup
+
+	host topology.Host
+
+	conn   *grpc.ClientConn
+	closed bool
+}
+
+func (p *peer) Host() topology.Host {
+	return p.host
+}
+
+func (p *peer) BorrowConnection(fn client.WithConnectionFn) (err error) {
+	p.Lock()
+	if p.closed {
+		p.Unlock()
+		return errPeerClosed
+	}
+
+	if p.conn == nil {
+		p.conn, err = grpc.Dial(p.host.Address(), grpc.WithInsecure())
+		if err != nil {
+			p.Unlock()
+			return err
+		}
+	}
+
+	conn := p.conn
+	p.Add(1)
+	p.Unlock()
+
+	fn(rpc.NewPeerDataNodeClient(conn))
+	p.Done()
+	return nil
+}
+
+func (p *peer) Close() {
+	utils.GetLogger().With("host", p.host.String()).Info("closing peer connection")
+	// waiting for on going operation with client connection
+	p.Wait()
+
+	p.Lock()
+	defer p.Unlock()
+	if p.conn != nil {
+		p.conn = nil
+		p.closed = true
+		err := p.conn.Close()
+		if err != nil {
+			utils.GetLogger().With("host", p.host.String(), "error", err.Error()).Error("failed to close grpc connection")
+		}
+	}
+}
+
+func NewPeer(host topology.Host) *peer {
+	return &peer{
+		host: host,
+	}
+}
+
+type peerSource struct {
+	sync.RWMutex
+
+	watch topology.MapWatch
+	peers map[string]*peer
+
+	done chan struct{}
+}
+
+func (ps *peerSource) BorrowConnection(hostID string, fn client.WithConnectionFn) error {
+	ps.RLock()
+	peer, exist := ps.peers[hostID]
+	if !exist {
+		ps.RUnlock()
+		return errPeerNotExist
+	}
+	ps.RUnlock()
+
+	return peer.BorrowConnection(fn)
+}
+
+func (ps *peerSource) watchTopoChange() {
+	for {
+		select {
+		case <-ps.watch.C():
+			ps.updateTopoMap(ps.watch.Get())
+		case <-ps.done:
+			return
+		}
+	}
+}
+
+func (ps *peerSource) Close() {
+	close(ps.done)
+
+	ps.Lock()
+	defer ps.Unlock()
+	for _, peer := range ps.peers {
+		peer.Close()
+	}
+}
+
+func (ps *peerSource) updateTopoMap(topoMap topology.Map) {
+	ps.Lock()
+	defer ps.Unlock()
+
+	// unknown host
+	knownHosts := make(map[string]struct{})
+	for _, host := range topoMap.Hosts() {
+		knownHosts[host.ID()] = struct{}{}
+		if _, exist := ps.peers[host.ID()]; !exist {
+			ps.peers[host.ID()] = NewPeer(host)
+		}
+	}
+
+	for hostID, peer := range ps.peers {
+		if _, known := knownHosts[hostID]; !known {
+			delete(ps.peers, hostID)
+			go func() {
+				peer.Close()
+			}()
+		}
+	}
+}
+
+// NewPeerSource creates PeerSource
+func NewPeerSource(topo topology.Topology) (client.PeerSource, error) {
+	mapWatch, err := topo.Watch()
+	if err != nil {
+		return nil, err
+	}
+
+	<-mapWatch.C()
+	topoMap := mapWatch.Get()
+
+	ps := &peerSource{
+		watch: mapWatch,
+		done:  make(chan struct{}),
+		peers: make(map[string]*peer),
+	}
+
+	ps.updateTopoMap(topoMap)
+	go ps.watchTopoChange()
+
+	return ps, nil
+}

--- a/datanode/peer_source_test.go
+++ b/datanode/peer_source_test.go
@@ -47,5 +47,7 @@ var _ = ginkgo.Describe("peer source", func() {
 		})
 		Ω(err).ShouldNot(BeNil())
 		Ω(workWithConn).Should(Equal(1))
+
+		peerSource.Close()
 	})
 })

--- a/datanode/peer_source_test.go
+++ b/datanode/peer_source_test.go
@@ -47,7 +47,5 @@ var _ = ginkgo.Describe("peer source", func() {
 		})
 		Ω(err).ShouldNot(BeNil())
 		Ω(workWithConn).Should(Equal(1))
-
-		peerSource.Close()
 	})
 })

--- a/datanode/peer_source_test.go
+++ b/datanode/peer_source_test.go
@@ -1,0 +1,51 @@
+package datanode
+
+import (
+	m3Shard "github.com/m3db/m3/src/cluster/shard"
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	aresShard "github.com/uber/aresdb/cluster/shard"
+	"github.com/uber/aresdb/cluster/topology"
+	"github.com/uber/aresdb/datanode/generated/proto/rpc"
+	"go.uber.org/zap"
+)
+
+var _ = ginkgo.Describe("peer source", func() {
+
+	host0 := topology.NewHost("instance0", "http://host0:9374")
+	host1 := topology.NewHost("instance1", "http://host1:9374")
+
+	staticMapOption := topology.NewStaticOptions().
+		SetReplicas(1).
+		SetHostShardSets([]topology.HostShardSet{
+			topology.NewHostShardSet(host0, aresShard.NewShardSet([]m3Shard.Shard{
+				m3Shard.NewShard(0),
+			})),
+			topology.NewHostShardSet(host1, aresShard.NewShardSet([]m3Shard.Shard{
+				m3Shard.NewShard(0),
+			})),
+		}).SetShardSet(aresShard.NewShardSet([]m3Shard.Shard{
+		m3Shard.NewShard(0),
+	}))
+
+	staticTopology, _ := topology.NewStaticInitializer(staticMapOption).Init()
+
+	ginkgo.It("BorrowConnection should work", func() {
+		logger := zap.NewExample()
+		peerSource, err := NewPeerSource(staticTopology)
+		Ω(err).Should(BeNil())
+		workWithConn := 0
+		err = peerSource.BorrowConnection("instance0", func(client rpc.PeerDataNodeClient) {
+			logger.Info("borrowed connection")
+			workWithConn++
+		})
+		Ω(err).Should(BeNil())
+		Ω(workWithConn).Should(Equal(1))
+
+		err = peerSource.BorrowConnection("instance3", func(client rpc.PeerDataNodeClient) {
+			workWithConn++
+		})
+		Ω(err).ShouldNot(BeNil())
+		Ω(workWithConn).Should(Equal(1))
+	})
+})


### PR DESCRIPTION
implementation of PeerSource interface
manages grpc connections to all peers in the cluster
use topology to add new peer and close old peers

major file changes:
datanode/peer_source.go
