### PR TITLE
explicit set CXX standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,10 @@ if (QUERY_MODE STREQUAL "DEVICE" AND USE_RMM)
     add_library(rmm SHARED IMPORTED)
     set_target_properties(rmm PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/lib/librmm.so)
     add_dependencies(rmm project_rmm)
+    include_directories(
+            ${RMM_SRC_DIR}/include
+            ${RMM_SRC_DIR}/thirdparty/cnmem/include
+    )
 endif ()
 ######################################################
 # CUDF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,26 @@ if (NOT QUERY_MODE)
     endif ()
 endif ()
 
+if(NOT WIN32)
+  string(ASCII 27 Esc)
+  set(ColourReset "${Esc}[m")
+  set(ColourBold  "${Esc}[1m")
+  set(Red         "${Esc}[31m")
+  set(Green       "${Esc}[32m")
+  set(Yellow      "${Esc}[33m")
+  set(Blue        "${Esc}[34m")
+  set(Magenta     "${Esc}[35m")
+  set(Cyan        "${Esc}[36m")
+  set(White       "${Esc}[37m")
+  set(BoldRed     "${Esc}[1;31m")
+  set(BoldGreen   "${Esc}[1;32m")
+  set(BoldYellow  "${Esc}[1;33m")
+  set(BoldBlue    "${Esc}[1;34m")
+  set(BoldMagenta "${Esc}[1;35m")
+  set(BoldCyan    "${Esc}[1;36m")
+  set(BoldWhite   "${Esc}[1;37m")
+endif()
+
 ################################
 # Compiler and linker flags
 ################################
@@ -60,9 +80,10 @@ set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
 # HASH_REDUCTION right now is only support in device mode and when CXX standard is C++14.
-if ((QUERY_MODE STRNEQUAL "DEVICE") OR (${CXX_STANDARD} EQUAL 14))
+if ((NOT QUERY_MODE STREQUAL "DEVICE") OR (${CXX_STANDARD} EQUAL 14))
     list(APPEND MARCROS "SUPPORT_HASH_REDUCTION=1")
     set(SUPPORT_HASH_REDUCTION 1)
+    message("${Green}Hash reduction is supported${ColourReset}!")
 endif ()
 
 ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,8 @@ add_custom_target(aresd DEPENDS lib ${ALL_GO_SRC_LIST}
         VERBATIM
         )
 
-add_custom_target(aresbrokerd DEPENDS ${ALL_GO_SRC_LIST}	
-        COMMAND go build -o bin/aresbrokerd ./cmd/broker/main.go	
+add_custom_target(aresbrokerd DEPENDS ${ALL_GO_SRC_LIST}
+        COMMAND go build -o bin/aresbrokerd ./cmd/broker/main.go
         VERBATIM	
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,12 @@ endif ()
 ################################
 # Compiler and linker flags
 ################################
-set(CXX_STANDARD 11)
-message("Detecting whether compiler support C++14")
-foreach (FEATURE ${CMAKE_CXX_COMPILE_FEATURES})
-    if (FEATURE STREQUAL "cxx_std_14")
-        message("C++14 is supported")
-        set(CXX_STANDARD 14)
-    endif ()
-endforeach ()
+# Explicitly set the CXX_STANDARD instead of detecting from
+# CMAKE_CXX_FEATURES since NVCC has its own way to check whether
+# host compiler supports specific CXX_STANDARD.
+if (NOT DEFINED CXX_STANDARD)
+    set(CXX_STANDARD 11)
+endif ()
 
 set(CMAKE_CUDA_STANDARD ${CXX_STANDARD})
 set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
@@ -247,11 +245,6 @@ add_custom_target(lib DEPENDS algorithm mem)
 string(REPLACE " " ";" ALL_GO_SRC_LIST ${ALL_GO_SRC})
 add_custom_target(aresd DEPENDS lib ${ALL_GO_SRC_LIST}
         COMMAND go build -o bin/aresd ./cmd/aresd/main.go
-        VERBATIM
-        )
-
-add_custom_target(aresbrokerd DEPENDS ${ALL_GO_SRC_LIST}
-        COMMAND go build -o bin/aresbrokerd ./cmd/broker/main.go
         VERBATIM
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,11 @@ add_custom_target(aresd DEPENDS lib ${ALL_GO_SRC_LIST}
         VERBATIM
         )
 
+add_custom_target(aresbrokerd DEPENDS ${ALL_GO_SRC_LIST}	
+        COMMAND go build -o bin/aresbrokerd ./cmd/broker/main.go	
+        VERBATIM	
+        )
+
 add_custom_target(ares-subscriber DEPENDS rdkafka::rdkafka ${ALL_GO_SRC_LIST}
         COMMAND go build -tags static -o bin/ares-subscriber ./cmd/subscriber/main.go
         VERBATIM

--- a/query/hash_reduction.cu
+++ b/query/hash_reduction.cu
@@ -38,7 +38,6 @@ CGoCallResHandle HashReduce(DimensionVector inputKeys,
   try {
 #ifndef SUPPORT_HASH_REDUCTION
     resHandle.res = reinterpret_cast<void *>(0);
-    return resHandle;
 #else
 #ifdef RUN_ON_DEVICE
     cudaSetDevice(device);
@@ -53,6 +52,7 @@ CGoCallResHandle HashReduce(DimensionVector inputKeys,
                                                                   aggFunc,
                                                                   cudaStream));
     CheckCUDAError("HashReduce");
+#endif
   }
   catch (std::exception &e) {
     std::cerr << "Exception happend when doing Reduce:" << e.what()
@@ -61,7 +61,6 @@ CGoCallResHandle HashReduce(DimensionVector inputKeys,
   }
   return resHandle;
 }
-#endif
 
 #ifdef SUPPORT_HASH_REDUCTION
 namespace ares {


### PR DESCRIPTION
Explicitly set the CXX_STANDARD instead of detecting from
CMAKE_CXX_FEATURES since NVCC has its own way to check whether
host compiler supports specific CXX_STANDARD.