### PR TITLE
respect data only mode

### DIFF
--- a/query/aql_postprocessor.go
+++ b/query/aql_postprocessor.go
@@ -113,18 +113,11 @@ func (qc *AQLQueryContext) flushResultBuffer() {
 				}
 			}
 
-			enumDict := dpc.reverseDicts[dimIndex]
-
-			// TODO: enable this logic when broker is ready to translate enums
-			// whether to translate enum:
-			// 1. for non agg query
-			//    1a. if local enum still exists, translate
-			//    1b. if no local enum, won't translate
-			// 2. agg query: skip translate if query is from broker (DataOnly == true)
-			//enumDict := []string{}
-			//if !qc.DataOnly || qc.IsNonAggregationQuery {
-			//	enumDict = dpc.reverseDicts[dimIndex]
-			//}
+			// don't translate enum if it's for distributed mode (DataOnly == true)
+			var enumDict []string
+			if !qc.DataOnly {
+				enumDict = dpc.reverseDicts[dimIndex]
+			}
 
 			dimValues[dimIndex] = queryCom.ReadDimension(
 				valuePtr, nullPtr, i, dpc.dimensionDataTypes[dimIndex], enumDict,


### PR DESCRIPTION
`DataOnly` flag is set to true means the following:
 - the query is a "distributed mode" query, or,
 - it's sent from aresdb-broker

in this mode, we do several special things compared to single instance mode:
 - for non agg query, we ignore response header(the column name list) and  stream out only the individual rows, as the headers and packaging to json object will be handled in the broker
 - for both non agg and agg queries, we skip enum translation, as in distributed mode the source of truth of enums is in the controller, and broker will cache it in memory and be responsible for translating enum in the post processing phase