### PR TITLE
fix errors in table deletion

### DIFF
--- a/api/schema_handler.go
+++ b/api/schema_handler.go
@@ -108,7 +108,7 @@ func (handler *SchemaHandler) GetTable(w http.ResponseWriter, r *http.Request) {
 
 	table, err := handler.metaStore.GetTable(getTableRequest.TableName)
 	if err != nil {
-		if err.Error() == metastore.ErrTableDoesNotExist.Error() {
+		if err.Error() == metaCom.ErrTableDoesNotExist.Error() {
 			common.RespondBytesWithCode(w, http.StatusNotFound, []byte(err.Error()))
 			return
 		}

--- a/api/schema_handler_test.go
+++ b/api/schema_handler_test.go
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe("SchemaHandler", func() {
 
 	ginkgo.It("GetTable should work", func() {
 		testMetaStore.On("GetTable", "testTable").Return(&testTable, nil)
-		testMetaStore.On("GetTable", "unknown").Return(nil, metastore.ErrTableDoesNotExist)
+		testMetaStore.On("GetTable", "unknown").Return(nil, metaCom.ErrTableDoesNotExist)
 		resp, err := http.Get(fmt.Sprintf("http://%s/schema/tables/%s", hostPort, "testTable"))
 		Ω(resp.StatusCode).Should(Equal(http.StatusOK))
 		Ω(err).Should(BeNil())

--- a/broker/broker_schema_mutator.go
+++ b/broker/broker_schema_mutator.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	memCom "github.com/uber/aresdb/memstore/common"
-	"github.com/uber/aresdb/metastore"
 	"github.com/uber/aresdb/metastore/common"
 	"github.com/uber/aresdb/utils"
 	"sync"
@@ -52,7 +51,7 @@ func (b *BrokerSchemaMutator) ListTables() (tables []string, err error) {
 func (b *BrokerSchemaMutator) GetTable(name string) (table *common.Table, err error) {
 	tableSchema, ok := b.tables[name]
 	if !ok {
-		err = metastore.ErrTableDoesNotExist
+		err = common.ErrTableDoesNotExist
 		return
 	}
 	table = &tableSchema.Schema

--- a/controller/mutators/etcd/enum_mutator.go
+++ b/controller/mutators/etcd/enum_mutator.go
@@ -15,7 +15,7 @@ package etcd
 
 import (
 	"github.com/uber/aresdb/cluster/kvstore"
-	common2 "github.com/uber/aresdb/metastore/common"
+	metaCom "github.com/uber/aresdb/metastore/common"
 	"path"
 	"strconv"
 	"sync"
@@ -67,7 +67,7 @@ func (e *enumMutator) ExtendEnumCases(namespace, tableName, columnName string, e
 		}
 	}
 	if columnID < 0 {
-		return nil, common2.ErrColumnDoesNotExist
+		return nil, metaCom.ErrColumnDoesNotExist
 	}
 
 	e.RLock()
@@ -257,7 +257,7 @@ func (e *enumMutator) GetEnumCases(namespace, tableName, columnName string) ([]s
 		}
 	}
 	if columnID < 0 {
-		return nil, common2.ErrColumnDoesNotExist
+		return nil, metaCom.ErrColumnDoesNotExist
 	}
 
 	cacheKey := getCacheKey(namespace, tableName, schema.Incarnation, columnID)

--- a/controller/mutators/etcd/enum_mutator.go
+++ b/controller/mutators/etcd/enum_mutator.go
@@ -15,6 +15,7 @@ package etcd
 
 import (
 	"github.com/uber/aresdb/cluster/kvstore"
+	common2 "github.com/uber/aresdb/metastore/common"
 	"path"
 	"strconv"
 	"sync"
@@ -23,7 +24,6 @@ import (
 	"github.com/uber/aresdb/controller/mutators/common"
 
 	"github.com/m3db/m3/src/cluster/kv"
-	"github.com/uber/aresdb/metastore"
 	"github.com/uber/aresdb/utils"
 )
 
@@ -67,7 +67,7 @@ func (e *enumMutator) ExtendEnumCases(namespace, tableName, columnName string, e
 		}
 	}
 	if columnID < 0 {
-		return nil, metastore.ErrColumnDoesNotExist
+		return nil, common2.ErrColumnDoesNotExist
 	}
 
 	e.RLock()
@@ -257,7 +257,7 @@ func (e *enumMutator) GetEnumCases(namespace, tableName, columnName string) ([]s
 		}
 	}
 	if columnID < 0 {
-		return nil, metastore.ErrColumnDoesNotExist
+		return nil, common2.ErrColumnDoesNotExist
 	}
 
 	cacheKey := getCacheKey(namespace, tableName, schema.Incarnation, columnID)

--- a/controller/mutators/etcd/schema_mutator.go
+++ b/controller/mutators/etcd/schema_mutator.go
@@ -63,7 +63,7 @@ func (m *tableSchemaMutator) GetTable(namespace, name string) (table *metaCom.Ta
 	}
 
 	if schemaProto.Tomstoned {
-		return nil, metastore.ErrTableDoesNotExist
+		return nil, metaCom.ErrTableDoesNotExist
 	}
 
 	table = &metaCom.Table{}
@@ -109,7 +109,7 @@ func (m *tableSchemaMutator) CreateTable(namespace string, table *metaCom.Table,
 
 	tableListProto, incarnation, exist := addEntity(tableListProto, table.Name)
 	if exist {
-		return metastore.ErrTableAlreadyExist
+		return metaCom.ErrTableAlreadyExist
 	}
 	table.Incarnation = incarnation
 
@@ -145,7 +145,7 @@ func (m *tableSchemaMutator) DeleteTable(namespace, name string) error {
 
 	tableListProto, found := deleteEntity(tableListProto, name)
 	if !found {
-		return metastore.ErrTableDoesNotExist
+		return metaCom.ErrTableDoesNotExist
 	}
 
 	// found table
@@ -155,7 +155,7 @@ func (m *tableSchemaMutator) DeleteTable(namespace, name string) error {
 	}
 
 	if schemaProto.Tomstoned {
-		return metastore.ErrTableDoesNotExist
+		return metaCom.ErrTableDoesNotExist
 	}
 	schemaProto.Tomstoned = true
 
@@ -226,7 +226,7 @@ func (m *tableSchemaMutator) UpdateTable(namespace string, table metaCom.Table, 
 		return err
 	}
 	if schemaProto.Tomstoned {
-		return metastore.ErrTableDoesNotExist
+		return metaCom.ErrTableDoesNotExist
 	}
 
 	var oldTable metaCom.Table
@@ -296,7 +296,7 @@ func (m *tableSchemaMutator) GetHash(namespace string) (hash string, err error) 
 func (m *tableSchemaMutator) readSchema(namespace string, name string) (schemaProto pb.EntityConfig, version int, err error) {
 	version, err = readValue(m.txnStore, utils.SchemaKey(namespace, name), &schemaProto)
 	if common.IsNonExist(err) {
-		err = metastore.ErrTableDoesNotExist
+		err = metaCom.ErrTableDoesNotExist
 	}
 	return
 }

--- a/memstore/backfill.go
+++ b/memstore/backfill.go
@@ -18,11 +18,11 @@ import (
 	"github.com/uber/aresdb/memstore/vectors"
 	"sort"
 
-	"github.com/uber/aresdb/memstore/common"
 	"github.com/uber/aresdb/utils"
 	"time"
 
 	memCom "github.com/uber/aresdb/memstore/common"
+	metaCom "github.com/uber/aresdb/metaStore/common"
 )
 
 // Backfill is the process of merging records with event time older than cutoff with
@@ -74,6 +74,10 @@ func (m *memStoreImpl) Backfill(table string, shardID int, reporter BackfillJobD
 
 	if err = shard.createNewArchiveStoreVersionForBackfill(
 		backfillPatches, reporter, jobKey); err != nil {
+		if err == metaCom.ErrTableDoesNotExist {
+			utils.GetLogger().With("table", table, "shard", shardID).Warn("failed to create archive store version for non-exist table")
+			return nil
+		}
 		return err
 	}
 

--- a/memstore/host_memory_manager.go
+++ b/memstore/host_memory_manager.go
@@ -276,7 +276,8 @@ func (h *hostMemoryManager) GetArchiveMemoryUsageByTableShard() (map[string]map[
 	for tableName, batchInfoByColumn := range h.batchInfosByColumn {
 		tableSchema, err := h.memStore.GetSchema(tableName)
 		if err != nil {
-			return managedMemoryUsage, err
+			// ignore deleted table
+			continue
 		}
 		for columnID, batchInfo := range batchInfoByColumn {
 			tableSchema.RLock()

--- a/memstore/schema.go
+++ b/memstore/schema.go
@@ -16,7 +16,6 @@ package memstore
 
 import (
 	memCom "github.com/uber/aresdb/memstore/common"
-	"github.com/uber/aresdb/metastore"
 	metaCom "github.com/uber/aresdb/metastore/common"
 	"github.com/uber/aresdb/utils"
 )
@@ -68,7 +67,7 @@ func (m *memStoreImpl) FetchSchema() error {
 func (m *memStoreImpl) fetchTable(tableName string) error {
 	table, err := m.metaStore.GetTable(tableName)
 	if err != nil {
-		if err != metastore.ErrTableDoesNotExist {
+		if err != metaCom.ErrTableDoesNotExist {
 			return utils.StackError(err, "Failed to get table schema for table %s from meta", tableName)
 		}
 	} else {
@@ -78,7 +77,7 @@ func (m *memStoreImpl) fetchTable(tableName string) error {
 				if column.IsEnumColumn() {
 					enumCases, err := m.metaStore.GetEnumDict(tableName, column.Name)
 					if err != nil {
-						if err != metastore.ErrTableDoesNotExist && err != metastore.ErrColumnDoesNotExist {
+						if err != metaCom.ErrTableDoesNotExist && err != metaCom.ErrColumnDoesNotExist {
 							return utils.StackError(err, "Failed to fetch enum cases for table: %s, column: %s", tableName, column.Name)
 						}
 					} else {
@@ -99,7 +98,7 @@ func (m *memStoreImpl) fetchTable(tableName string) error {
 func (m *memStoreImpl) watchEnumCases(tableName, columnName string, startCase int) error {
 	enumDictChangeEvents, done, err := m.metaStore.WatchEnumDictEvents(tableName, columnName, startCase)
 	if err != nil {
-		if err != metastore.ErrTableDoesNotExist && err != metastore.ErrColumnDoesNotExist {
+		if err != metaCom.ErrTableDoesNotExist && err != metaCom.ErrColumnDoesNotExist {
 			return utils.StackError(err, "Failed to watch enum case events")
 		}
 	} else {

--- a/memstore/schema_test.go
+++ b/memstore/schema_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/uber/aresdb/common"
 	memCom "github.com/uber/aresdb/memstore/common"
 	memComMocks "github.com/uber/aresdb/memstore/common/mocks"
-	"github.com/uber/aresdb/metastore"
 	metaCom "github.com/uber/aresdb/metastore/common"
 	"github.com/uber/aresdb/metastore/mocks"
 	"github.com/uber/aresdb/redolog"
@@ -330,7 +329,7 @@ var _ = ginkgo.Describe("memStoreImpl schema", func() {
 
 		// failed with table no exist error
 		mockMetastore.On("ListTables").Return([]string{testTable.Name}, nil).Once()
-		mockMetastore.On("GetTable", testTable.Name).Return(nil, metastore.ErrTableDoesNotExist).Once()
+		mockMetastore.On("GetTable", testTable.Name).Return(nil, metaCom.ErrTableDoesNotExist).Once()
 		doneChan = make(chan struct{})
 		mockMetastore.On("WatchTableListEvents").Return(recvTableListEvents, doneChan, nil).Once()
 		doneChan = make(chan struct{})
@@ -348,7 +347,7 @@ var _ = ginkgo.Describe("memStoreImpl schema", func() {
 		// failed with column does not exist error
 		mockMetastore.On("ListTables").Return([]string{"testTable"}, nil).Once()
 		mockMetastore.On("GetTable", testTable.Name).Return(&testTable, nil).Once()
-		mockMetastore.On("GetEnumDict", testTable.Name, testColumn2.Name).Return(nil, metastore.ErrColumnDoesNotExist).Once()
+		mockMetastore.On("GetEnumDict", testTable.Name, testColumn2.Name).Return(nil, metaCom.ErrColumnDoesNotExist).Once()
 		mockMetastore.On("GetEnumDict", testTable.Name, testColumn3.Name).Return(testColumn3EnumCases, nil).Once()
 		doneChan = make(chan struct{})
 		mockMetastore.On("WatchTableListEvents").Return(recvTableListEvents, doneChan, nil).Once()

--- a/metastore/common/errors.go
+++ b/metastore/common/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metastore
+package common
 
 import (
 	"errors"

--- a/metastore/disk_metastore_test.go
+++ b/metastore/disk_metastore_test.go
@@ -252,7 +252,7 @@ var _ = ginkgo.Describe("disk metastore", func() {
 		Ω(err).Should(BeNil())
 		Ω(*table).Should(Equal(testTableA))
 		_, err = diskMetaStore.GetTable("unknown")
-		Ω(err).Should(Equal(ErrTableDoesNotExist))
+		Ω(err).Should(Equal(common.ErrTableDoesNotExist))
 	})
 
 	ginkgo.It("GetEnumDict", func() {
@@ -425,7 +425,7 @@ var _ = ginkgo.Describe("disk metastore", func() {
 	ginkgo.It("CreateTable", func() {
 		diskMetaStore := createDiskMetastore("base")
 		err := diskMetaStore.CreateTable(&testTableA)
-		Ω(err).Should(Equal(ErrTableAlreadyExist))
+		Ω(err).Should(Equal(common.ErrTableAlreadyExist))
 
 		// should work without watchers
 		err = diskMetaStore.CreateTable(&testTableC)
@@ -460,7 +460,7 @@ var _ = ginkgo.Describe("disk metastore", func() {
 	ginkgo.It("DeleteTable", func() {
 		diskMetaStore := createDiskMetastore("base")
 		err := diskMetaStore.DeleteTable(testTableC.Name)
-		Ω(err).Should(Equal(ErrTableDoesNotExist))
+		Ω(err).Should(Equal(common.ErrTableDoesNotExist))
 
 		// should work without watchers
 		err = diskMetaStore.DeleteTable(testTableB.Name)
@@ -482,10 +482,10 @@ var _ = ginkgo.Describe("disk metastore", func() {
 	ginkgo.It("AddColumn", func() {
 		diskMetaStore := createDiskMetastore("base")
 		err := diskMetaStore.AddColumn("unknown", testColumn1, true)
-		Ω(err).Should(Equal(ErrTableDoesNotExist))
+		Ω(err).Should(Equal(common.ErrTableDoesNotExist))
 
 		err = diskMetaStore.AddColumn(testTableA.Name, testColumn1, true)
-		Ω(err).Should(Equal(ErrDuplicatedColumnName))
+		Ω(err).Should(Equal(common.ErrDuplicatedColumnName))
 
 		err = diskMetaStore.AddColumn(testTableA.Name, testColumn2, true)
 		Ω(err).Should(BeNil())
@@ -524,13 +524,13 @@ var _ = ginkgo.Describe("disk metastore", func() {
 	ginkgo.It("DeleteColumn", func() {
 		diskMetaStore := createDiskMetastore("base")
 		err := diskMetaStore.DeleteColumn("unknown", testColumn1.Name)
-		Ω(err).Should(Equal(ErrTableDoesNotExist))
+		Ω(err).Should(Equal(common.ErrTableDoesNotExist))
 
 		err = diskMetaStore.DeleteColumn(testTableA.Name, "unknown")
-		Ω(err).Should(Equal(ErrColumnDoesNotExist))
+		Ω(err).Should(Equal(common.ErrColumnDoesNotExist))
 
 		err = diskMetaStore.DeleteColumn(testTableA.Name, testColumn0.Name)
-		Ω(err).Should(Equal(ErrDeleteTimeColumn))
+		Ω(err).Should(Equal(common.ErrDeleteTimeColumn))
 
 		events, done, err := diskMetaStore.WatchTableSchemaEvents()
 		Ω(err).Should(BeNil())
@@ -560,13 +560,13 @@ var _ = ginkgo.Describe("disk metastore", func() {
 	ginkgo.It("UpdateColumn", func() {
 		diskMetaStore := createDiskMetastore("base")
 		err := diskMetaStore.UpdateColumn("unknown", testColumn1.Name, testColumnConfig1)
-		Ω(err).Should(Equal(ErrTableDoesNotExist))
+		Ω(err).Should(Equal(common.ErrTableDoesNotExist))
 
 		err = diskMetaStore.UpdateColumn(testTableA.Name, "unknown", testColumnConfig1)
-		Ω(err).Should(Equal(ErrColumnDoesNotExist))
+		Ω(err).Should(Equal(common.ErrColumnDoesNotExist))
 
 		err = diskMetaStore.UpdateColumn(testTableA.Name, testColumn5.Name, testColumnConfig1)
-		Ω(err).Should(Equal(ErrColumnDoesNotExist))
+		Ω(err).Should(Equal(common.ErrColumnDoesNotExist))
 
 		events, done, err := diskMetaStore.WatchTableSchemaEvents()
 		Ω(err).Should(BeNil())

--- a/metastore/validator_test.go
+++ b/metastore/validator_test.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrMissingTimeColumn))
+		Ω(err).Should(Equal(common.ErrMissingTimeColumn))
 	})
 
 	ginkgo.It("should return err for missing pk", func() {
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrMissingPrimaryKey))
+		Ω(err).Should(Equal(common.ErrMissingPrimaryKey))
 	})
 
 	ginkgo.It("should return err for dup column name", func() {
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrDuplicatedColumnName))
+		Ω(err).Should(Equal(common.ErrDuplicatedColumnName))
 	})
 
 	ginkgo.It("should return err for dup column", func() {
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrDuplicatedColumn))
+		Ω(err).Should(Equal(common.ErrDuplicatedColumn))
 	})
 
 	ginkgo.It("should return err for dup column", func() {
@@ -115,7 +115,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrDuplicatedColumn))
+		Ω(err).Should(Equal(common.ErrDuplicatedColumn))
 	})
 
 	ginkgo.It("should return err for too few columns", func() {
@@ -127,7 +127,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(table)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrAllColumnsInvalid))
+		Ω(err).Should(Equal(common.ErrAllColumnsInvalid))
 	})
 
 	ginkgo.It("should be happy with valid updates", func() {
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrSchemaUpdateNotAllowed))
+		Ω(err).Should(Equal(common.ErrSchemaUpdateNotAllowed))
 	})
 
 	ginkgo.It("should fail for table type change", func() {
@@ -251,7 +251,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrSchemaUpdateNotAllowed))
+		Ω(err).Should(Equal(common.ErrSchemaUpdateNotAllowed))
 	})
 
 	ginkgo.It("should fail for number of columns reduction", func() {
@@ -287,7 +287,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrInsufficientColumnCount))
+		Ω(err).Should(Equal(common.ErrInsufficientColumnCount))
 	})
 
 	ginkgo.It("should fail for modification on deleted column", func() {
@@ -328,7 +328,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrReusingColumnIDNotAllowed))
+		Ω(err).Should(Equal(common.ErrReusingColumnIDNotAllowed))
 	})
 
 	ginkgo.It("should fail for modification on immutable column fields", func() {
@@ -368,7 +368,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrSchemaUpdateNotAllowed))
+		Ω(err).Should(Equal(common.ErrSchemaUpdateNotAllowed))
 
 		// modify hll config not allowed
 		oldTable = common.Table{
@@ -409,7 +409,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err = validator.Validate()
-		Ω(err).Should(Equal(ErrSchemaUpdateNotAllowed))
+		Ω(err).Should(Equal(common.ErrSchemaUpdateNotAllowed))
 	})
 
 	ginkgo.It("should fail for changing pk cloumns", func() {
@@ -445,7 +445,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrChangePrimaryKeyColumn))
+		Ω(err).Should(Equal(common.ErrChangePrimaryKeyColumn))
 	})
 
 	ginkgo.It("should fail for changing sort columns", func() {
@@ -498,7 +498,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrIllegalChangeSortColumn))
+		Ω(err).Should(Equal(common.ErrIllegalChangeSortColumn))
 
 		// changing existing sort columns is not allowed
 		oldTable.ArchivingSortColumns = []int{1}
@@ -506,7 +506,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err = validator.Validate()
-		Ω(err).Should(Equal(ErrIllegalChangeSortColumn))
+		Ω(err).Should(Equal(common.ErrIllegalChangeSortColumn))
 	})
 
 	ginkgo.It("ValidateDefaultValue should work", func() {
@@ -569,7 +569,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator := NewTableSchameValidator()
 		validator.SetNewTable(newTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrTimeColumnDoesNotAllowDefault))
+		Ω(err).Should(Equal(common.ErrTimeColumnDoesNotAllowDefault))
 	})
 
 	ginkgo.It("should fail when disallow missing event time", func() {
@@ -623,7 +623,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator.SetNewTable(newTable)
 		validator.SetOldTable(oldTable)
 		err := validator.Validate()
-		Ω(err).Should(Equal(ErrDisallowMissingEventTime))
+		Ω(err).Should(Equal(common.ErrDisallowMissingEventTime))
 
 		oldTable = common.Table{
 			Name: "testTable",
@@ -724,7 +724,7 @@ var _ = ginkgo.Describe("Validator", func() {
 		validator = NewTableSchameValidator()
 		validator.SetNewTable(table2)
 		err = validator.Validate()
-		Ω(err).Should(Equal(ErrTimeColumnDoesNotAllowHLLConfig))
+		Ω(err).Should(Equal(common.ErrTimeColumnDoesNotAllowHLLConfig))
 	})
 
 	ginkgo.It("should fail when table config is invalid", func() {


### PR DESCRIPTION
1. it is possible to have tables deleted in metastore when scheduled jobs are already running and trying to create new versions in metastore, in such case we should not panic and crash the server

2. host memory manager should ignore deleted tables when reporting memory usage