### PR TITLE
time duration instead of second since client side is sending duration directly

### DIFF
--- a/datanode/bootstrap/bootstrap_server.go
+++ b/datanode/bootstrap/bootstrap_server.go
@@ -92,7 +92,7 @@ func (p *PeerDataNodeServerImpl) AcquireToken(tableName string, shardID uint32) 
 	// lazy clean the obsolete orphan sessions
 	now := utils.Now()
 	for sid, session := range p.sessions {
-		if now.After(session.lastLiveTime.Add(time.Second * time.Duration(session.ttl))) {
+		if now.After(session.lastLiveTime.Add(time.Duration(session.ttl))) {
 			p.cleanSession(sid, false)
 		}
 	}

--- a/datanode/bootstrap/bootstrap_server_test.go
+++ b/datanode/bootstrap/bootstrap_server_test.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("bootstrap server", func() {
 
 	req := pb.StartSessionRequest{
 		Shard: uint32(shardID),
-		Ttl:   5 * 60,
+		Ttl:   int64(5 * time.Minute),
 	}
 
 	var testServer *grpc.Server
@@ -139,7 +139,7 @@ var _ = ginkgo.Describe("bootstrap server", func() {
 			err = keepAliveClient.Send(&pb.Session{ID: session.ID, NodeID: nodeID})
 			resp, err := keepAliveClient.Recv()
 			Ω(err).Should(BeNil())
-			Ω(resp.Ttl).Should(Equal(int64(300)))
+			Ω(resp.Ttl).Should(Equal(int64(5 * time.Minute)))
 			time.Sleep(time.Millisecond * 10)
 		}
 		err = keepAliveClient.CloseSend()


### PR DESCRIPTION
this is causing server side in non purge mode essentially forever when client side crashed