### PR TITLE
hll memory estimate in MB instead of Bytes

### DIFF
--- a/query/aql_processor.go
+++ b/query/aql_processor.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	hllQueryRequiredMemoryInMB = 10 * 1024
+	hllQueryRequiredMemoryInBytes = 10 * (1 << 30)
 )
 
 // batchTransferExecutor defines the type of the functor to transfer a live batch or a archive batch
@@ -974,7 +974,7 @@ func (qc *AQLQueryContext) calculateMemoryRequirement(memStore memstore.MemStore
 	//we can track memory usage
 	//based on table, dimensions, duration to do estimation
 	if qc.OOPK.IsHLL() {
-		return hllQueryRequiredMemoryInMB
+		return hllQueryRequiredMemoryInBytes
 	}
 
 	for _, shardID := range qc.TableScanners[0].Shards {


### PR DESCRIPTION
this drastically under estimate memory usage for hll query and cause out of memory situation during massive hll query hits, such as weekly hll contracts