### PR TITLE
block int64 for binary transformations

### DIFF
--- a/broker/query_compiler.go
+++ b/broker/query_compiler.go
@@ -256,6 +256,14 @@ func (qc *QueryContext) processFilters() {
 		if qc.Error != nil {
 			return
 		}
+		if be, ok1 := qc.AQLQuery.FiltersParsed[i].(*expr.BinaryExpr); ok1 {
+			if vr, ok2 := be.LHS.(*expr.VarRef); ok2 {
+				if memCom.Int64 == vr.DataType {
+					qc.Error = utils.StackError(nil, "Int64 can not be used in filters, %s", vr.Val)
+					return
+				}
+			}
+		}
 	}
 
 	qc.AQLQuery.FiltersParsed = normalizeAndFilters(qc.AQLQuery.FiltersParsed)

--- a/broker/query_compiler.go
+++ b/broker/query_compiler.go
@@ -488,7 +488,7 @@ func (qc *QueryContext) Rewrite(expression expr.Expr) expr.Expr {
 			qc.Error = err
 			return expression
 		}
-
+		// TODO: @shz support int64 binary transform
 		if err := blockInt64(e.LHS, e.RHS); err != nil {
 			qc.Error = err
 			return expression

--- a/broker/query_compiler_test.go
+++ b/broker/query_compiler_test.go
@@ -34,6 +34,7 @@ var _ = ginkgo.Describe("query compiler", func() {
 		Columns: []metaCom.Column{
 			{Name: "field1", Type: "Uint32"},
 			{Name: "field2", Type: "Uint16"},
+			{Name: "field3", Type: "Int64"},
 		},
 	}
 	tableSchema1 := memCom.NewTableSchema(table1)
@@ -153,6 +154,7 @@ var _ = ginkgo.Describe("query compiler", func() {
 			Dimensions: []common.Dimension{
 				{Expr: "field1", ExprParsed: &expr.VarRef{Val: "field1", ExprType: 2, DataType: memCom.Uint32}},
 				{Expr: "field2", ExprParsed: &expr.VarRef{Val: "field2", ColumnID: 1, ExprType: 2, DataType: memCom.Uint16}},
+				{Expr: "field3", ExprParsed: &expr.VarRef{Val: "field3", ColumnID: 2, ExprType: 3, DataType: memCom.Int64}},
 			},
 			Measures: []common.Measure{
 				{
@@ -215,6 +217,30 @@ var _ = ginkgo.Describe("query compiler", func() {
 		}, false, httptest.NewRecorder())
 		qc.Compile(&mockTableSchemaReader)
 		Ω(qc.Error).ShouldNot(BeNil())
+	})
+
+	ginkgo.It("should fail int64 filters", func() {
+		mockTableSchemaReader := memComMocks.TableSchemaReader{}
+		mockTableSchemaReader.On("RLock").Return(nil)
+		mockTableSchemaReader.On("RUnlock").Return(nil)
+		mockTableSchemaReader.On("GetSchema", "table1").Return(tableSchema1, nil)
+		qc := NewQueryContext(&common.AQLQuery{
+			Table: "table1",
+			Dimensions: []common.Dimension{
+				{
+					Expr: "field1",
+				},
+			},
+			Measures: []common.Measure{
+				{
+					Expr: "count(*)",
+				},
+			},
+			Filters: []string{"field3 = 1"},
+		}, false, httptest.NewRecorder())
+		qc.Compile(&mockTableSchemaReader)
+		Ω(qc.Error).ShouldNot(BeNil())
+		Ω(qc.Error.Error()).Should(ContainSubstring("Int64 can not be used in filters"))
 	})
 
 	ginkgo.It("should fail more than 1 measure", func() {

--- a/broker/query_compiler_test.go
+++ b/broker/query_compiler_test.go
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("query compiler", func() {
 		Ω(qc.Error).ShouldNot(BeNil())
 	})
 
-	ginkgo.It("should fail int64 filters", func() {
+	ginkgo.It("should fail int64 binary transform", func() {
 		mockTableSchemaReader := memComMocks.TableSchemaReader{}
 		mockTableSchemaReader.On("RLock").Return(nil)
 		mockTableSchemaReader.On("RUnlock").Return(nil)
@@ -240,7 +240,7 @@ var _ = ginkgo.Describe("query compiler", func() {
 		}, false, httptest.NewRecorder())
 		qc.Compile(&mockTableSchemaReader)
 		Ω(qc.Error).ShouldNot(BeNil())
-		Ω(qc.Error.Error()).Should(ContainSubstring("Int64 can not be used in filters"))
+		Ω(qc.Error.Error()).Should(ContainSubstring("binary transformation not allowed for int64 fields"))
 	})
 
 	ginkgo.It("should fail more than 1 measure", func() {

--- a/query/aql_compiler.go
+++ b/query/aql_compiler.go
@@ -1496,6 +1496,14 @@ func (qc *AQLQueryContext) processFilters() {
 				geoFilterFound = true
 			}
 		} else {
+			if be, ok1 := filter.(*expr.BinaryExpr); ok1 {
+				if vr, ok2 := be.LHS.(*expr.VarRef); ok2 {
+					if memCom.Int64 == vr.DataType {
+						qc.Error = utils.StackError(nil, "Int64 can not be used in filters, %s", vr.Val)
+						return
+					}
+				}
+			}
 			qc.OOPK.MainTableCommonFilters = append(qc.OOPK.MainTableCommonFilters, filter)
 		}
 	}

--- a/query/aql_compiler.go
+++ b/query/aql_compiler.go
@@ -687,6 +687,7 @@ func (qc *AQLQueryContext) Rewrite(expression expr.Expr) expr.Expr {
 			return expression
 		}
 
+		// TODO: @shz support int64 binary transform
 		if err := blockInt64(e.LHS, e.RHS); err != nil {
 			qc.Error = err
 			return expression

--- a/query/aql_compiler_test.go
+++ b/query/aql_compiler_test.go
@@ -4151,9 +4151,7 @@ var _ = ginkgo.Describe("AQL compiler", func() {
 		qc.parseExprs()
 		Ω(qc.Error).Should(BeNil())
 		qc.resolveTypes()
-		Ω(qc.Error).Should(BeNil())
-		qc.processFilters()
-		Ω(qc.Error.Error()).Should(ContainSubstring("Int64 can not be used in filters, int64_field"))
+		Ω(qc.Error.Error()).Should(ContainSubstring("binary transformation not allowed for int64 fields"))
 
 	})
 })


### PR DESCRIPTION
int64 type can not be used for binary transformations for now.
currently query fail until c++ type binding phase, add validation logic to fail those in compilation time.