### PR TITLE
use GetVectorParty for safe vp request

### DIFF
--- a/query/aql_processor.go
+++ b/query/aql_processor.go
@@ -433,7 +433,7 @@ func (qc *AQLQueryContext) prepareForeignTable(memStore memstore.MemStore, joinT
 		for i, columnID := range qc.TableScanners[joinTableID+1].Columns {
 			usage := qc.TableScanners[joinTableID+1].ColumnUsages[columnID]
 			if usage&(columnUsedByAllBatches|columnUsedByLiveBatches) != 0 {
-				sourceVP := batch.Columns[columnID]
+				sourceVP := batch.GetVectorParty(columnID)
 				if sourceVP == nil {
 					continue
 				}
@@ -515,7 +515,7 @@ func (qc *AQLQueryContext) transferLiveBatch(batch *memstore.LiveBatch, size int
 				if firstColumn < 0 {
 					firstColumn = i
 				}
-				sourceVP := batch.Columns[columnID]
+				sourceVP := batch.GetVectorParty(columnID)
 				if sourceVP == nil {
 					continue
 				}
@@ -1043,7 +1043,7 @@ func (qc *AQLQueryContext) calculateMemoryRequirement(memStore memstore.MemStore
 func (qc *AQLQueryContext) estimateLiveBatchMemoryUsage(batch *memstore.LiveBatch) int {
 	columnMemUsage := 0
 	for _, columnID := range qc.TableScanners[0].Columns {
-		sourceVP := batch.Columns[columnID]
+		sourceVP := batch.GetVectorParty(columnID)
 		if sourceVP == nil {
 			continue
 		}
@@ -1279,7 +1279,7 @@ func (qc *AQLQueryContext) calculateForeignTableMemUsage(memStore memstore.MemSt
 			for _, columnID := range qc.TableScanners[joinTableID+1].Columns {
 				usage := qc.TableScanners[joinTableID+1].ColumnUsages[columnID]
 				if usage&(columnUsedByAllBatches|columnUsedByLiveBatches) != 0 {
-					sourceVP := batch.Columns[columnID]
+					sourceVP := batch.GetVectorParty(columnID)
 					if sourceVP == nil {
 						continue
 					}
@@ -1483,7 +1483,7 @@ func shouldSkipLiveBatchWithFilter(b *memstore.LiveBatch, filter expr.Expr) bool
 
 		if columnExpr != nil && numExpr != nil {
 			// Time filters and main table filters are guaranteed to be on main table.
-			vp := b.Columns[columnExpr.ColumnID]
+			vp := b.GetVectorParty(columnExpr.ColumnID)
 			if vp == nil {
 				return true
 			}


### PR DESCRIPTION
panic on vector party request when columnID >= len(batch.Columns)
this could happen when new column is created in table but no ingestion happen on the column before query. currently we only expand batch.Columns during ingestion using GetOrCreateVectorParty call

```
panic: runtime error: index out of range

goroutine 1666532 [running]:
github.com/uber/aresdb/query.(*AQLQueryContext).estimateLiveBatchMemoryUsage(0xc03694b800, 0xc001b58300, 0xc001b58300)
        /home/shz/gocode/pkg/mod/github.com/uber/aresdb@v0.0.3-0.20191028200138-affd4a9f8540/query/aql_processor.go:1046 +0x2c7
github.com/uber/aresdb/query.(*AQLQueryContext).calculateMemoryRequirement(0xc03694b800, 0x16d5d20, 0xc000f9c120, 0x14f575f)
        /home/shz/gocode/pkg/mod/github.com/uber/aresdb@v0.0.3-0.20191028200138-affd4a9f8540/query/aql_processor.go:1006 +0xf1
github.com/uber/aresdb/query.(*AQLQueryContext).FindDeviceForQuery(0xc03694b800, 0x16d5d20, 0xc000f9c120, 0xffffffffffffffff, 0xc000780b40, 0xffffffffffffffff)
        /home/shz/gocode/pkg/mod/github.com/uber/aresdb@v0.0.3-0.20191028200138-affd4a9f8540/query/aql_processor.go:1300 +0x49
github.com/uber/aresdb/api.handleQuery(0x16d5d20, 0xc000f9c120, 0x16a7560, 0xc000af8440, 0xc000780b40, 0xffffffffffffffff, 0x0, 0x0, 0x0, 0x0, ...)
```