### PR TITLE
Refactor get primary key values to reduce ingestion latency

### DIFF
--- a/memstore/archive_store.go
+++ b/memstore/archive_store.go
@@ -305,7 +305,7 @@ func (b *ArchiveBatch) BuildIndex(sortColumns []int, primaryKeyColumns []int, pk
 		return nil
 	}
 
-	var key []byte
+	key := make([]byte, b.Shard.Schema.PrimaryKeyBytes)
 	var err error
 	primaryKeyValues := make([]common.DataValue, len(primaryKeyColumns))
 
@@ -341,7 +341,9 @@ func (b *ArchiveBatch) BuildIndex(sortColumns []int, primaryKeyColumns []int, pk
 		}
 
 		// Get primary key for each record.
-		if key, err = common.GetPrimaryKeyBytes(primaryKeyValues, b.Shard.Schema.PrimaryKeyBytes); err != nil {
+		// truncate key
+		key = key[:0]
+		if key, err = common.AppendPrimaryKeyBytes(key, common.NewSliceDataValueIterator(primaryKeyValues)); err != nil {
 			return err
 		}
 

--- a/memstore/common/primary_key.go
+++ b/memstore/common/primary_key.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 	"unsafe"
 
 	"github.com/uber/aresdb/utils"
@@ -93,11 +94,12 @@ func MarshalPrimaryKey(pk PrimaryKey) ([]byte, error) {
 	})
 }
 
-// GetPrimaryKeyBytes returns primary key bytes for a given row.
-func GetPrimaryKeyBytes(primaryKeyValues []DataValue, keyLength int) ([]byte, error) {
-	key := make([]byte, 0, keyLength)
-	for _, value := range primaryKeyValues {
+// AppendPrimaryKeyBytes writes primary keys bytes into key buffer
+func AppendPrimaryKeyBytes(key []byte, primaryKeyValues DataValueIterator) ([]byte, error) {
+	for !primaryKeyValues.done() {
+		value := primaryKeyValues.read()
 		if !value.Valid {
+			fmt.Println("hello world")
 			return key, utils.StackError(nil, "Primary key cannot be null")
 		}
 
@@ -112,6 +114,7 @@ func GetPrimaryKeyBytes(primaryKeyValues []DataValue, keyLength int) ([]byte, er
 				key = append(key, *(*byte)(utils.MemAccess(value.OtherVal, i)))
 			}
 		}
+		primaryKeyValues.next()
 	}
 	return key, nil
 }

--- a/memstore/common/primary_key_test.go
+++ b/memstore/common/primary_key_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = ginkgo.Describe("primary key", func() {
-	ginkgo.It("GetPrimaryKeyBytes should work", func() {
+	ginkgo.It("AppendPrimaryKeyBytes should work", func() {
 		var v1 uint16 = 0xA0B0
 		var v2 uint32 = 0xC0D0E0F0
 		dataValues := []DataValue{
@@ -44,7 +44,8 @@ var _ = ginkgo.Describe("primary key", func() {
 			},
 		}
 
-		key, err := GetPrimaryKeyBytes(dataValues, 7)
+		key := make([]byte, 0, 7)
+		key, err := AppendPrimaryKeyBytes(key, NewSliceDataValueIterator(dataValues))
 		Ω(err).Should(BeNil())
 		Ω(key).Should(BeEquivalentTo([]byte{1, 0xB0, 0XA0, 0xF0, 0xE0, 0xD0, 0xC0}))
 	})

--- a/memstore/common/upsert_batch_test.go
+++ b/memstore/common/upsert_batch_test.go
@@ -458,7 +458,7 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		upsertBatchBytes, _ := builder.ToByteArray()
 		upsertBatch, _ := NewUpsertBatch(upsertBatchBytes)
 
-		dv, _ := upsertBatch.GetDataValue(0, 3)
+		dv := upsertBatch.GetDataValue(0, 3)
 		Ω(dv.ConvertToHumanReadable(UUID)).Should(Equal(uuidStr))
 	})
 
@@ -490,11 +490,11 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		newBatch := upsertBatch.ExtractBackfillBatch([]int{1})
 
 		Ω(newBatch.NumRows).Should(Equal(1))
-		dv, _ := newBatch.GetDataValue(0, 2)
+		dv := newBatch.GetDataValue(0, 2)
 		Ω(dv.ConvertToHumanReadable(UUID)).Should(Equal(uuidStr))
-		dv, _ = newBatch.GetDataValue(0, 0)
+		dv = newBatch.GetDataValue(0, 0)
 		Ω(dv.ConvertToHumanReadable(Float32)).Should(Equal(float32(1.2)))
-		dv, _ = newBatch.GetDataValue(0, 1)
+		dv = newBatch.GetDataValue(0, 1)
 		Ω(dv.ConvertToHumanReadable(Bool)).Should(Equal(false))
 	})
 
@@ -531,11 +531,11 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		newBatch := upsertBatch.ExtractBackfillBatch([]int{1})
 
 		Ω(newBatch.NumRows).Should(Equal(1))
-		dv, _ := newBatch.GetDataValue(0, 0)
+		dv := newBatch.GetDataValue(0, 0)
 		Ω(dv.ConvertToHumanReadable(Float32)).Should(Equal(float32(1.2)))
-		dv, _ = newBatch.GetDataValue(0, 1)
+		dv = newBatch.GetDataValue(0, 1)
 		Ω(dv.ConvertToHumanReadable(Bool)).Should(Equal(false))
-		dv, _ = newBatch.GetDataValue(0, 2)
+		dv = newBatch.GetDataValue(0, 2)
 		Ω(dv.ConvertToHumanReadable(UUID)).Should(Equal(uuidStr))
 		Ω(upsertBatch.NumColumns).Should(Equal(4))
 		Ω(newBatch.NumColumns).Should(Equal(3))
@@ -561,14 +561,12 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		upsertBatch, _ := NewUpsertBatch(upsertBatchBytes)
 
 		// first row should have value
-		value, err := upsertBatch.GetDataValue(0, 0)
-		Ω(err).Should(BeNil())
+		value := upsertBatch.GetDataValue(0, 0)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(*(*uint32)(value.OtherVal)).Should(Equal(uint32(2)))
 
-		value, err = upsertBatch.GetDataValue(0, 1)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(0, 1)
 		Ω(value).ShouldNot(BeNil())
 		expectedShape := &GeoShapeGo{
 			Polygons: [][]GeoPointGo{
@@ -587,25 +585,21 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		Ω(value.Valid).Should(BeTrue())
 		Ω(value.GoVal).Should(Equal(expectedShape))
 
-		value, err = upsertBatch.GetDataValue(0, 2)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(0, 2)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(value.BoolVal).Should(BeTrue())
 
 		// second row should be all nil
-		value, err = upsertBatch.GetDataValue(1, 0)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 0)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeFalse())
 
-		value, err = upsertBatch.GetDataValue(1, 1)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 1)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeFalse())
 
-		value, err = upsertBatch.GetDataValue(1, 2)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 2)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeFalse())
 	})
@@ -643,20 +637,17 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		upsertBatch, _ := NewUpsertBatch(upsertBatchBytes)
 
 		// first row should have value
-		value, err := upsertBatch.GetDataValue(0, 0)
-		Ω(err).Should(BeNil())
+		value := upsertBatch.GetDataValue(0, 0)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(*(*uint16)(value.OtherVal)).Should(Equal(uint16(1)))
 
-		value, err = upsertBatch.GetDataValue(0, 2)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(0, 2)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(*(*int32)(value.OtherVal)).Should(Equal(int32(101)))
 
-		value, err = upsertBatch.GetDataValue(0, 1)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(0, 1)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		reader := NewArrayValueReader(value.DataType, value.OtherVal)
@@ -674,20 +665,17 @@ var _ = ginkgo.Describe("upsert batch", func() {
 		Ω(*(*int32)(reader.Get(2))).Should(Equal(int32(13)))
 
 		// second row
-		value, err = upsertBatch.GetDataValue(1, 0)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 0)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(*(*uint16)(value.OtherVal)).Should(Equal(uint16(2)))
 
-		value, err = upsertBatch.GetDataValue(1, 2)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 2)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 		Ω(*(*int32)(value.OtherVal)).Should(Equal(int32(102)))
 
-		value, err = upsertBatch.GetDataValue(1, 1)
-		Ω(err).Should(BeNil())
+		value = upsertBatch.GetDataValue(1, 1)
 		Ω(value).ShouldNot(BeNil())
 		Ω(value.Valid).Should(BeTrue())
 

--- a/memstore/ingestion.go
+++ b/memstore/ingestion.go
@@ -184,7 +184,7 @@ func (shard *TableShard) insertPrimaryKeys(primaryKeyColumns []int, eventTimeCol
 	isFactTable := shard.Schema.Schema.IsFactTable
 	shard.Schema.RUnlock()
 
-	var key []byte
+	key := make([]byte, primaryKeyBytes)
 	updateRecords := make(map[int32][]recordInfo)
 	insertRecords := make(map[int32][]recordInfo)
 
@@ -202,7 +202,9 @@ func (shard *TableShard) insertPrimaryKeys(primaryKeyColumns []int, eventTimeCol
 	var maxUpsertBatchEventTime uint32
 	for row := 0; row < upsertBatch.NumRows; row++ {
 		// Get primary key bytes for each record.
-		if key, err = upsertBatch.GetPrimaryKeyBytes(row, primaryKeyCols, primaryKeyBytes); err != nil {
+		// truncate key
+		key = key[:0]
+		if key, err = common.AppendPrimaryKeyBytes(key, common.NewPrimaryKeyDataValueIterator(upsertBatch, row, primaryKeyCols)); err != nil {
 			return nil, nil, nil, utils.StackError(err, "Failed to create primary key at row %d", row)
 		}
 

--- a/memstore/snapshot_test.go
+++ b/memstore/snapshot_test.go
@@ -237,12 +237,15 @@ var _ = ginkgo.Describe("snapshot", func() {
 
 		// check if the primray key rebuilt and can data be found
 		primaryKeyBytes := shard.Schema.PrimaryKeyBytes
-		var key []byte
+		key := make([]byte, primaryKeyBytes)
 		primaryKeyValues := make([]memCom.DataValue, 1)
 
 		for row := 0; row <= rows; row++ {
 			primaryKeyValues[0], _ = memCom.ValueFromString(fmt.Sprintf("%d", row+1), memCom.Uint16)
-			key, err = memCom.GetPrimaryKeyBytes(primaryKeyValues, primaryKeyBytes)
+			// truncate key
+			key = key[:0]
+			// write primary key bytes
+			key, err = memCom.AppendPrimaryKeyBytes(key, memCom.NewSliceDataValueIterator(primaryKeyValues))
 
 			Ω(err).Should(BeNil())
 			record, found := shard.LiveStore.PrimaryKey.Find(key)

--- a/memstore/test_factory_test.go
+++ b/memstore/test_factory_test.go
@@ -120,31 +120,31 @@ var _ = ginkgo.Describe("test factory", func() {
 		Ω(ub.GetColumnType(1)).Should(Equal(common.Bool))
 		Ω(ub.GetColumnID(1)).Should(Equal(1))
 
-		val, err := ub.GetDataValue(0, 0)
+		val := ub.GetDataValue(0, 0)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeTrue())
 		Ω(*(*uint16)(val.OtherVal)).Should(BeEquivalentTo(16))
 
-		val, err = ub.GetDataValue(0, 1)
+		val = ub.GetDataValue(0, 1)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeTrue())
 		Ω(val.BoolVal).Should(Equal(true))
 
-		val, err = ub.GetDataValue(1, 0)
+		val = ub.GetDataValue(1, 0)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeFalse())
 
-		val, err = ub.GetDataValue(1, 1)
+		val = ub.GetDataValue(1, 1)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeTrue())
 		Ω(val.BoolVal).Should(Equal(false))
 
-		val, err = ub.GetDataValue(2, 0)
+		val = ub.GetDataValue(2, 0)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeTrue())
 		Ω(*(*uint16)(val.OtherVal)).Should(BeEquivalentTo(0))
 
-		val, err = ub.GetDataValue(2, 1)
+		val = ub.GetDataValue(2, 1)
 		Ω(err).Should(BeNil())
 		Ω(val.Valid).Should(BeTrue())
 		Ω(val.BoolVal).Should(Equal(true))

--- a/query/aql_processor_test.go
+++ b/query/aql_processor_test.go
@@ -1460,7 +1460,8 @@ var _ = ginkgo.Describe("aql_processor", func() {
 			uuidValue, _ := memCom.ValueFromString(shapeUUIDs[i], memCom.UUID)
 			shapeUUIDLiveVP.SetDataValue(i, uuidValue, memCom.IgnoreCount)
 			shapeLiveVP.SetDataValue(i, memCom.DataValue{Valid: true, GoVal: &shapes[i]}, memCom.IgnoreCount)
-			key, err := memCom.GetPrimaryKeyBytes([]memCom.DataValue{uuidValue}, 16)
+			key := make([]byte, 0, 16)
+			key, err := memCom.AppendPrimaryKeyBytes(key, memCom.NewSliceDataValueIterator([]memCom.DataValue{uuidValue}))
 			Ω(err).Should(BeNil())
 			geoFenceLiveStore.PrimaryKey.FindOrInsert(
 				key,
@@ -1726,7 +1727,8 @@ var _ = ginkgo.Describe("aql_processor", func() {
 			uuidValue, _ := memCom.ValueFromString(shapeUUIDs[i], memCom.UUID)
 			shapeUUIDLiveVP.SetDataValue(i, uuidValue, memCom.IgnoreCount)
 			shapeLiveVP.SetDataValue(i, memCom.DataValue{Valid: true, GoVal: &shapes[i]}, memCom.IgnoreCount)
-			key, err := memCom.GetPrimaryKeyBytes([]memCom.DataValue{uuidValue}, 16)
+			key := make([]byte, 0, 16)
+			key, err := memCom.AppendPrimaryKeyBytes(key, memCom.NewSliceDataValueIterator([]memCom.DataValue{uuidValue}))
 			Ω(err).Should(BeNil())
 			geoFenceLiveStore.PrimaryKey.FindOrInsert(
 				key,

--- a/subscriber/common/rules/job_config.go
+++ b/subscriber/common/rules/job_config.go
@@ -166,7 +166,7 @@ func (j *JobConfig) SetPrimaryKeyBytes(primaryKeyBytes int) {
 	j.primaryKeyBytes = primaryKeyBytes
 }
 
-// GetPrimaryKeyBytes returns the number of bytes needed by primaryKey
+// AppendPrimaryKeyBytes returns the number of bytes needed by primaryKey
 func (j *JobConfig) GetPrimaryKeyBytes() int {
 	return j.primaryKeyBytes
 }

--- a/subscriber/common/sink/sink.go
+++ b/subscriber/common/sink/sink.go
@@ -87,7 +87,9 @@ func shardFn(key []byte, numShards uint32) uint32 {
 func getPrimaryKeyBytes(row client.Row, destination Destination, jobConfig *rules.JobConfig, keyLength int) ([]byte, error) {
 	primaryKeyValues := make([]memCom.DataValue, len(destination.PrimaryKeys))
 	var err error
-	var key, strBytes []byte
+	// create empty key with keyLength capacity
+	key := make([]byte, 0, keyLength)
+	var strBytes []byte
 	i := 0
 	for columnName, columnID := range destination.PrimaryKeys {
 		columnIDInSchema := destination.PrimaryKeysInSchema[columnName]
@@ -112,7 +114,7 @@ func getPrimaryKeyBytes(row client.Row, destination Destination, jobConfig *rule
 		}
 	}
 
-	if key, err = memCom.GetPrimaryKeyBytes(primaryKeyValues, keyLength); err != nil {
+	if key, err = memCom.AppendPrimaryKeyBytes(key, memCom.NewSliceDataValueIterator(primaryKeyValues)); err != nil {
 		return key, err
 	}
 	if strBytes != nil {

--- a/subscriber/common/sink/sink_test.go
+++ b/subscriber/common/sink/sink_test.go
@@ -127,7 +127,8 @@ var _ = Describe("Sink", func() {
 			Ω(val.ConvertToHumanReadable(memCom.UUID).(string)).Should(Equal(keyVal))
 			primaryKeyValues[0] = val
 			keyLen := memCom.DataTypeBits(val.DataType) / 8
-			pk, err := memCom.GetPrimaryKeyBytes(primaryKeyValues, keyLen)
+			key := make([]byte, 0, keyLen)
+			pk, err := memCom.AppendPrimaryKeyBytes(key, memCom.NewSliceDataValueIterator(primaryKeyValues))
 			Ω(err).Should(BeNil())
 			shardID1 := utils.Murmur3Sum32(unsafe.Pointer(&pk[0]), len(pk), 0) / (math.MaxUint32 / numShards)
 			shardID2 := utils.Murmur3Sum32(unsafe.Pointer(&pk[0]), len(pk), 0) % numShards

--- a/utils/http.go
+++ b/utils/http.go
@@ -113,7 +113,7 @@ func LimitServe(port int, handler http.Handler, httpCfg common.HTTPConfig) {
 	GetLogger().Fatal(server.Serve(listener))
 }
 
-// LimitServe will start a http server on the port with the handler and at most maxConnection concurrent connections.
+// LimitServeAsync will start a http server on the port with the handler and at most maxConnection concurrent connections.
 func LimitServeAsync(port int, handler http.Handler, httpCfg common.HTTPConfig) (chan error, *http.Server) {
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
@@ -167,7 +167,7 @@ func NewMetricsLoggingMiddleWareProvider(scope tally.Scope, logger common.Logger
 	}
 }
 
-// WithLogging plug in metrics middleware
+// WithMetrics plug in metrics middleware
 func (p *MetricsLoggingMiddleWareProvider) WithMetrics(next HandlerFunc) HandlerFunc {
 	funcName := GetFuncName(next)
 	return func(rw *ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Profiling shows that insert primary key has majority time taken in two allocations
1. primaryKeyValues := make([]DataValue, len(primaryKeyCols)) LINE 323
2. key := make([]byte, 0, keyLength) LINE 98


fixes
* the first allocated slice primaryKeyValues is just for temporarily holding the primary key data values so we can remove and use a iterator interface instead

* the second allocation is done on each row for every upsert batch, since primary key bytes are the same for each upsert batch, we can just allocate one key slice and share.

* additionally, modified upsertBatch.GetDataValue method signature to make it fit the BatchReader interface

```
ROUTINE ======================== github.com/uber/aresdb/memstore/common.(*UpsertBatch).GetPrimaryKeyBytes in /home/jians/gocode/pkg/mod/github.com/uber/aresdb@v0.0.3-0.20191212190927-a425d38c8c4d/memstore/common/upsert_batch.go
     1.12s     11.74s (flat, cum) 17.59% of Total
         .          .    315:	return primaryKeyCols, nil
         .          .    316:}
         .          .    317:
         .          .    318:// GetPrimaryKeyBytes returns primary key bytes for a given row. Note primaryKeyCol is not list of primary key
         .          .    319:// columnIDs.
      80ms       80ms    320:func (u *UpsertBatch) GetPrimaryKeyBytes(row int, primaryKeyCols []int, keyLength int) ([]byte, error) {
         .          .    321:	var key []byte
         .          .    322:	var err error
     160ms      5.21s    323:	primaryKeyValues := make([]DataValue, len(primaryKeyCols))
      90ms       90ms    324:	for i, col := range primaryKeyCols {
     520ms      2.51s    325:		primaryKeyValues[i], err = u.GetDataValue(row, col)
         .          .    326:		if err != nil {
         .          .    327:			return key, utils.StackError(err, "Failed to read primary key at row %d, col %d",
         .          .    328:				row, col)
         .          .    329:		}
         .          .    330:	}
         .          .    331:
     270ms      3.85s    332:	return GetPrimaryKeyBytes(primaryKeyValues, keyLength)
         .          .    333:}
         .          .    334:
         .          .    335:// ExtractBackfillBatch extracts given rows and stores in a new UpsertBatch
         .          .    336:// The returned new UpsertBatch is not fully serialized and can only be used for
         .          .    337:// structured reads.
ROUTINE ======================== github.com/uber/aresdb/memstore/common.GetPrimaryKeyBytes in /home/jians/gocode/pkg/mod/github.com/uber/aresdb@v0.0.3-0.20191212190927-a425d38c8c4d/memstore/common/primary_key.go
     1.93s      3.59s (flat, cum)  5.38% of Total
         .          .     92:		"eventTimeCutoff": pk.GetEventTimeCutoff(),
         .          .     93:	})
         .          .     94:}
         .          .     95:
         .          .     96:// GetPrimaryKeyBytes returns primary key bytes for a given row.
      40ms       40ms     97:func GetPrimaryKeyBytes(primaryKeyValues []DataValue, keyLength int) ([]byte, error) {
      50ms      1.48s     98:	key := make([]byte, 0, keyLength)
     250ms      250ms     99:	for _, value := range primaryKeyValues {
     140ms      140ms    100:		if !value.Valid {
         .          .    101:			return key, utils.StackError(nil, "Primary key cannot be null")
         .          .    102:		}
         .          .    103:
      50ms       50ms    104:		if value.IsBool {
         .          .    105:			if value.BoolVal {
         .          .    106:				key = append(key, byte(1))
         .          .    107:			} else {
         .          .    108:				key = append(key, byte(0))
         .          .    109:			}
         .          .    110:		} else {
     600ms      720ms    111:			for i := 0; i < DataTypeBits(value.DataType)/8; i++ {
     740ms      850ms    112:				key = append(key, *(*byte)(utils.MemAccess(value.OtherVal, i)))
         .          .    113:			}
         .          .    114:		}
         .          .    115:	}
      60ms       60ms    116:	return key, nil
         .          .    117:}
```